### PR TITLE
Fix tsc rootDir warning in client

### DIFF
--- a/app/client/tsconfig.json
+++ b/app/client/tsconfig.json
@@ -10,5 +10,7 @@
     "baseUrl": "./src",
     "rootDir": "./src",
     "jsx": "react"
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- limit TypeScript compilation to the `src` directory in the client package
- exclude `vite.config.ts` from tsc

## Testing
- `yarn prettier:check` *(fails: connect EHOSTUNREACH)*