### PR TITLE
Add inventory purchase notification bubble

### DIFF
--- a/app/client/src/modules/application/application.component.tsx
+++ b/app/client/src/modules/application/application.component.tsx
@@ -20,6 +20,7 @@ import {
   SoundProvider,
   ItemPlacePreviewProvider,
   InfoProvider,
+  InventoryNotificationProvider,
   ChangelogProvider,
   LanguageProvider,
   ApiProvider,
@@ -50,6 +51,7 @@ export const ApplicationComponent = () => {
       RouterProvider,
       ModalProvider,
       InfoProvider,
+      InventoryNotificationProvider,
       //|\\|//|\\|//|\\|//|\\|//|\\|//|\\|//|\\|
       //|\\|//|\\|//|\\|//|\\|//|\\|//|\\|//|\\|
       PrivateRoomProvider,

--- a/app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx
+++ b/app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx
@@ -18,7 +18,13 @@ import {
   TextComponent,
 } from "shared/components";
 import { CatalogCategoryData } from "shared/types";
-import { useApi, useFurniture, SoundsEnum, useSound } from "shared/hooks";
+import {
+  useApi,
+  useFurniture,
+  SoundsEnum,
+  useSound,
+  useInventoryNotification,
+} from "shared/hooks";
 import { useTranslation } from "react-i18next";
 import { FURNITURE_ICON_BOX_SIZE, SCROLL_BAR_WIDTH } from "shared/consts";
 import { CATALOG_DEFAULT_CATEGORY_ITEM_LIST_SIZE } from "shared/consts/catalog.consts";
@@ -37,6 +43,7 @@ export const DefaultCategoryComponent: React.FC<Props> = ({
   const { fetch } = useApi();
   const { get } = useFurniture();
   const { play } = useSound();
+  const { increment } = useInventoryNotification();
 
   const { t } = useTranslation();
   const [selectedFurnitureId, setSelectedFurnitureId] = useState<string>(null);
@@ -109,9 +116,12 @@ export const DefaultCategoryComponent: React.FC<Props> = ({
       false,
       "POST",
     ).then(({ transaction }) => {
-      if (transaction?.success) play(SoundsEnum.BUY);
+      if (transaction?.success) {
+        play(SoundsEnum.BUY);
+        increment();
+      }
     });
-  }, [fetch, selectedFurnitureData, play]);
+  }, [fetch, selectedFurnitureData, play, increment]);
 
   const renderPreview = useMemo(() => {
     if (!selectedFurnitureData)

--- a/app/client/src/modules/modals/components/inventory/inventory.component.tsx
+++ b/app/client/src/modules/modals/components/inventory/inventory.component.tsx
@@ -12,7 +12,7 @@ import {
   useDragContainer,
 } from "@openhotel/pixi-components";
 import { Modal, ModalInventoryTab, SpriteSheetEnum } from "shared/enums";
-import { useModal } from "shared/hooks";
+import { useModal, useInventoryNotification } from "shared/hooks";
 import { ModalInventoryCategoryProps } from "shared/types";
 import { TextComponent } from "shared/components";
 import { MODAL_SIZE_MAP } from "shared/consts";
@@ -33,6 +33,7 @@ const MODAL_SIZE = MODAL_SIZE_MAP[Modal.INVENTORY];
 export const InventoryComponent: React.FC = () => {
   const { t } = useTranslation();
   const { closeModal } = useModal();
+  const { reset } = useInventoryNotification();
   const { setDragPolygon } = useDragContainer();
 
   const [selectedCategory, setSelectedCategory] = useState<ModalInventoryTab>(
@@ -57,6 +58,10 @@ export const InventoryComponent: React.FC = () => {
   useEffect(() => {
     setDragPolygon?.([0, 0, MODAL_SIZE.width, 0, MODAL_SIZE.width, 15, 0, 15]);
   }, [setDragPolygon]);
+
+  useEffect(() => {
+    reset();
+  }, [reset]);
 
   const SelectedCategoryContent = useMemo(
     () => inventoryCategoryMap[selectedCategory],

--- a/app/client/src/shared/components/hot-bar-items/hot-bar-items.component.tsx
+++ b/app/client/src/shared/components/hot-bar-items/hot-bar-items.component.tsx
@@ -1,13 +1,23 @@
 import React, { useCallback, useMemo } from "react";
-import { Cursor, EventMode, SpriteComponent } from "@openhotel/pixi-components";
+import {
+  ContainerComponent,
+  FLEX_ALIGN,
+  FLEX_JUSTIFY,
+  FlexContainerComponent,
+  Cursor,
+  EventMode,
+  SpriteComponent,
+} from "@openhotel/pixi-components";
 import { Modal, SpriteSheetEnum } from "shared/enums";
-import { useModal } from "shared/hooks";
+import { useModal, useInventoryNotification } from "shared/hooks";
+import { SoftBadgeComponent, TextComponent } from "shared/components";
 import { MODAL_HOT_BAR_ITEMS } from "shared/consts";
 
 type Props = {};
 
 export const HotBarItemsComponent: React.FC<Props> = ({}) => {
   const { openModal, closeModal, isModalOpen } = useModal();
+  const { count } = useInventoryNotification();
 
   const onPointerDown = useCallback(
     (modal: Modal) => () => {
@@ -23,17 +33,31 @@ export const HotBarItemsComponent: React.FC<Props> = ({}) => {
         .map((modal) => {
           const modalId = Number(modal) as Modal;
           const { icon } = MODAL_HOT_BAR_ITEMS[modalId];
+          const showBubble = modalId === Modal.INVENTORY && count > 0;
           return (
-            <SpriteComponent
-              key={modal}
-              spriteSheet={SpriteSheetEnum.HOT_BAR_ICONS}
-              texture={icon}
-              eventMode={EventMode.STATIC}
-              cursor={Cursor.POINTER}
-              onPointerDown={onPointerDown(modalId)}
-            />
+            <ContainerComponent key={modal}>
+              <SpriteComponent
+                spriteSheet={SpriteSheetEnum.HOT_BAR_ICONS}
+                texture={icon}
+                eventMode={EventMode.STATIC}
+                cursor={Cursor.POINTER}
+                onPointerDown={onPointerDown(modalId)}
+              />
+              {showBubble ? (
+                <ContainerComponent position={{ x: 12, y: -2 }}>
+                  <SoftBadgeComponent size={{ width: 9, height: 8 }} />
+                  <FlexContainerComponent
+                    size={{ width: 9, height: 8 }}
+                    justify={FLEX_JUSTIFY.CENTER}
+                    align={FLEX_ALIGN.CENTER}
+                  >
+                    <TextComponent text={count.toString()} color={0x000} />
+                  </FlexContainerComponent>
+                </ContainerComponent>
+              ) : null}
+            </ContainerComponent>
           );
         }),
-    [onPointerDown],
+    [onPointerDown, count],
   );
 };

--- a/app/client/src/shared/hooks/index.ts
+++ b/app/client/src/shared/hooks/index.ts
@@ -12,6 +12,7 @@ export * from "./safe-window";
 export * from "./sound";
 export * from "./item-place-preview";
 export * from "./info";
+export * from "./inventory-notification";
 export * from "./changelog";
 export * from "./language";
 export * from "./api";

--- a/app/client/src/shared/hooks/inventory-notification/index.ts
+++ b/app/client/src/shared/hooks/inventory-notification/index.ts
@@ -1,0 +1,4 @@
+export * from "./inventory-notification.context";
+export * from "./inventory-notification.provider";
+export * from "./inventory-notification.store";
+export * from "./use-inventory-notification";

--- a/app/client/src/shared/hooks/inventory-notification/inventory-notification.context.tsx
+++ b/app/client/src/shared/hooks/inventory-notification/inventory-notification.context.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export type InventoryNotificationState = {
+  count: number;
+  increment: (amount?: number) => void;
+  reset: () => void;
+};
+
+export const InventoryNotificationContext = React.createContext<InventoryNotificationState>(undefined);

--- a/app/client/src/shared/hooks/inventory-notification/inventory-notification.provider.tsx
+++ b/app/client/src/shared/hooks/inventory-notification/inventory-notification.provider.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode, useCallback } from "react";
+import { InventoryNotificationContext } from "./inventory-notification.context";
+import { useInventoryNotificationStore } from "./inventory-notification.store";
+
+type Props = { children: ReactNode };
+
+export const InventoryNotificationProvider: React.FC<Props> = ({ children }) => {
+  const { count, increment: $increment, reset: $reset } =
+    useInventoryNotificationStore();
+
+  const increment = useCallback(
+    (amount?: number) => $increment(amount),
+    [$increment],
+  );
+  const reset = useCallback(() => $reset(), [$reset]);
+
+  return (
+    <InventoryNotificationContext.Provider
+      value={{ count, increment, reset }}
+      children={children}
+    />
+  );
+};

--- a/app/client/src/shared/hooks/inventory-notification/inventory-notification.store.ts
+++ b/app/client/src/shared/hooks/inventory-notification/inventory-notification.store.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+
+export const useInventoryNotificationStore = create<{
+  count: number;
+  increment: (amount?: number) => void;
+  reset: () => void;
+}>((set) => ({
+  count: 0,
+  increment: (amount = 1) =>
+    set((state) => ({ count: state.count + amount })),
+  reset: () => set({ count: 0 }),
+}));

--- a/app/client/src/shared/hooks/inventory-notification/use-inventory-notification.tsx
+++ b/app/client/src/shared/hooks/inventory-notification/use-inventory-notification.tsx
@@ -1,0 +1,5 @@
+import { useContext } from "react";
+import { InventoryNotificationContext, InventoryNotificationState } from "./inventory-notification.context";
+
+export const useInventoryNotification = (): InventoryNotificationState =>
+  useContext(InventoryNotificationContext);


### PR DESCRIPTION
## Summary
- add inventory notification hooks and provider
- show a bubble on the inventory icon with the number of recent purchases
- reset the bubble when opening inventory
- increment the counter after a successful catalog buy

## Testing
- `yarn prettier:check` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.6.0/packages/yarnpkg-cli/bin/yarn.js)*