### PR TITLE
Add room password feature

### DIFF
--- a/app/client/src/assets/locales/en.json
+++ b/app/client/src/assets/locales/en.json
@@ -55,7 +55,13 @@
       "layout": "Layout",
       "title": "Title",
       "description": "Description",
-      "create_room": "Create room"
-    }
+    "password": "Password",
+    "create_room": "Create room"
   }
+  },
+  "room_password": {
+    "title": "Enter password",
+    "join": "Join"
+  }
+}
 }

--- a/app/client/src/assets/locales/es.json
+++ b/app/client/src/assets/locales/es.json
@@ -54,7 +54,12 @@
       "layout": "Distribución",
       "title": "Título",
       "description": "Descripción",
+      "password": "Contraseña",
       "create_room": "Crear sala"
     }
+  },
+  "room_password": {
+    "title": "Contraseña de la sala",
+    "join": "Entrar"
   }
 }

--- a/app/client/src/modules/modals/components/index.ts
+++ b/app/client/src/modules/modals/components/index.ts
@@ -5,3 +5,4 @@ export * from "./inventory";
 export * from "./navigator";
 export * from "./purse";
 export * from "./room-creator";
+export * from "./room-password";

--- a/app/client/src/modules/modals/components/navigator/components/category-me/category-me.component.tsx
+++ b/app/client/src/modules/modals/components/navigator/components/category-me/category-me.component.tsx
@@ -60,6 +60,7 @@ export const CategoryMeComponent: React.FC<Props> = ({ size }) => {
           maxUsers: room.maxUsers,
           favorite: false,
           layoutIndex: room.layoutIndex,
+          hasPassword: room.hasPassword,
         })),
       );
     });

--- a/app/client/src/modules/modals/components/navigator/components/category-rooms/category-rooms.component.tsx
+++ b/app/client/src/modules/modals/components/navigator/components/category-rooms/category-rooms.component.tsx
@@ -54,6 +54,7 @@ export const CategoryRoomsComponent: React.FC<Props> = ({ size }) => {
           maxUsers: room.maxUsers,
           favorite: false,
           layoutIndex: room.layoutIndex,
+          hasPassword: room.hasPassword,
         })),
       );
     });

--- a/app/client/src/modules/modals/components/navigator/components/category-rooms/components/room-preview/room-preview.component.tsx
+++ b/app/client/src/modules/modals/components/navigator/components/category-rooms/components/room-preview/room-preview.component.tsx
@@ -109,6 +109,9 @@ export const RoomPreviewComponent: React.FC<Props> = ({
           gap={6}
         >
           <TextComponent text={`${room.users}/${room.maxUsers}`} color={0} />
+          {room.hasPassword ? (
+            <TextComponent text="🔒" color={0xb73d22} />
+          ) : null}
           <ButtonComponent
             size={{
               height: 14,

--- a/app/client/src/modules/modals/components/navigator/components/category-rooms/components/rooms-list/rooms-list.component.tsx
+++ b/app/client/src/modules/modals/components/navigator/components/category-rooms/components/rooms-list/rooms-list.component.tsx
@@ -57,7 +57,7 @@ export const RoomsListComponent: React.FC<Props> = ({
         direction="y"
         gap={3}
       >
-        {rooms.map(({ id, title, users, maxUsers, favorite }, index) => (
+        {rooms.map(({ id, title, users, maxUsers, favorite, hasPassword }, index) => (
           <NavigatorRoomButtonComponent
             key={id}
             size={{
@@ -68,6 +68,7 @@ export const RoomsListComponent: React.FC<Props> = ({
             users={users}
             maxUsers={maxUsers}
             favorite={favorite}
+            locked={hasPassword}
             onPointerDown={$onPointerDown(id)}
             onClickFavorite={() => onClickFavorite(id)}
             onClickGo={() => onClickGo(id)}

--- a/app/client/src/modules/modals/components/room-creator/room-creator.component.tsx
+++ b/app/client/src/modules/modals/components/room-creator/room-creator.component.tsx
@@ -38,10 +38,12 @@ export const RoomCreatorComponent: React.FC = () => {
     id: number;
     title: string;
     description: string;
+    password: string;
   }>({
     id: null,
     title: null,
     description: null,
+    password: "",
   });
 
   useEffect(() => {
@@ -76,6 +78,7 @@ export const RoomCreatorComponent: React.FC = () => {
         layoutId: formRef.current.id,
         title: formRef.current.title,
         description: formRef.current.description,
+        password: formRef.current.password,
       },
       false,
       "PUT",
@@ -95,6 +98,9 @@ export const RoomCreatorComponent: React.FC = () => {
   }, []);
   const onChangeDescription = useCallback((value: KeyboardEventExtended) => {
     formRef.current.description = value.target.value;
+  }, []);
+  const onChangePassword = useCallback((value: KeyboardEventExtended) => {
+    formRef.current.password = value.target.value;
   }, []);
 
   return (
@@ -198,6 +204,21 @@ export const RoomCreatorComponent: React.FC = () => {
                 placeholder={t("room_creator.form.description")}
                 onChange={onChangeDescription}
                 maxLength={64}
+              />
+            </TitleComponent>
+            <TitleComponent
+              title={t("room_creator.form.password")}
+              position={{
+                y: 14 * 5,
+              }}
+            >
+              <InputComponent
+                size={{
+                  width: formWidth,
+                }}
+                placeholder={t("room_creator.form.password")}
+                onChange={onChangePassword}
+                maxLength={32}
               />
             </TitleComponent>
             {/*<TitleComponent*/}

--- a/app/client/src/modules/modals/components/room-password/index.ts
+++ b/app/client/src/modules/modals/components/room-password/index.ts
@@ -1,0 +1,1 @@
+export * from "./room-password.component";

--- a/app/client/src/modules/modals/components/room-password/room-password.component.tsx
+++ b/app/client/src/modules/modals/components/room-password/room-password.component.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import {
+  ContainerComponent,
+  Cursor,
+  EventMode,
+  FLEX_JUSTIFY,
+  FlexContainerComponent,
+  GraphicsComponent,
+  GraphicType,
+  NineSliceSpriteComponent,
+  TilingSpriteComponent,
+  useDragContainer,
+} from "@openhotel/pixi-components";
+import { ButtonComponent, InputComponent, TextComponent } from "shared/components";
+import { MODAL_SIZE_MAP } from "shared/consts";
+import { Event, Modal, SpriteSheetEnum } from "shared/enums";
+import { useModal, useProxy, useRoomPasswordModalStore } from "shared/hooks";
+import { useTranslation } from "react-i18next";
+
+const MODAL_SIZE = MODAL_SIZE_MAP[Modal.ROOM_PASSWORD];
+
+export const RoomPasswordComponent: React.FC = () => {
+  const { t } = useTranslation();
+  const { closeModal } = useModal();
+  const { emit } = useProxy();
+  const { roomId, setRoomId } = useRoomPasswordModalStore();
+  const { setDragPolygon } = useDragContainer();
+
+  const passwordRef = useRef<string>("");
+
+  useEffect(() => {
+    setDragPolygon?.([0, 0, MODAL_SIZE.width, 0, MODAL_SIZE.width, 20, 0, 20]);
+  }, [setDragPolygon]);
+
+  const onCloseModal = useCallback(() => {
+    closeModal(Modal.ROOM_PASSWORD);
+    setRoomId(null);
+  }, [closeModal, setRoomId]);
+
+  const onChangePassword = useCallback((e) => {
+    passwordRef.current = e.target.value;
+  }, []);
+
+  const onJoinRoom = useCallback(() => {
+    if (!roomId) return;
+    emit(Event.JOIN_ROOM, { roomId, password: passwordRef.current });
+    onCloseModal();
+  }, [emit, roomId, onCloseModal]);
+
+  const inputWidth = MODAL_SIZE.width - 24;
+
+  return (
+    <>
+      <GraphicsComponent
+        type={GraphicType.CIRCLE}
+        radius={6.5}
+        alpha={0}
+        cursor={Cursor.POINTER}
+        eventMode={EventMode.STATIC}
+        position={{ x: MODAL_SIZE.width - 23, y: 1.5 }}
+        onPointerDown={onCloseModal}
+        zIndex={20}
+        pivot={{ x: 0, y: -5 }}
+      />
+      <ContainerComponent>
+        <NineSliceSpriteComponent
+          spriteSheet={SpriteSheetEnum.UI}
+          texture="ui-base-modal"
+          leftWidth={14}
+          rightWidth={21}
+          topHeight={22}
+          bottomHeight={11}
+          height={MODAL_SIZE.height}
+          width={MODAL_SIZE.width}
+        />
+        <TilingSpriteComponent
+          texture="ui-base-modal-bar-tile"
+          spriteSheet={SpriteSheetEnum.UI}
+          position={{ x: 11, y: 4 }}
+          width={MODAL_SIZE.width - 35}
+        />
+        <FlexContainerComponent
+          justify={FLEX_JUSTIFY.CENTER}
+          size={{ width: MODAL_SIZE.width }}
+          position={{ y: 4 }}
+        >
+          <TextComponent
+            text={t("room_password.title")}
+            backgroundColor={0xacc1ed}
+            backgroundAlpha={1}
+            padding={{ left: 4, right: 3, bottom: 0, top: 2 }}
+          />
+        </FlexContainerComponent>
+        <ContainerComponent position={{ x: 12, y: 22 }}>
+          <InputComponent
+            size={{ width: inputWidth }}
+            placeholder={t("room_creator.form.password")}
+            onChange={onChangePassword}
+          />
+          <FlexContainerComponent
+            position={{ y: 20, x: 0 }}
+            size={{ width: inputWidth }}
+            justify={FLEX_JUSTIFY.END}
+          >
+            <ButtonComponent
+              text={t("room_password.join")}
+              autoWidth
+              size={{ height: 14 }}
+              onPointerDown={onJoinRoom}
+            />
+          </FlexContainerComponent>
+        </ContainerComponent>
+      </ContainerComponent>
+    </>
+  );
+};

--- a/app/client/src/shared/components/navigator-room-button/navigator-room-button.component.tsx
+++ b/app/client/src/shared/components/navigator-room-button/navigator-room-button.component.tsx
@@ -21,6 +21,8 @@ type Props = {
   maxUsers: number;
   size: Size;
 
+  locked?: boolean;
+
   onClickFavorite: () => void;
   onClickGo: () => void;
 } & ContainerProps;
@@ -32,6 +34,7 @@ export const NavigatorRoomButtonComponent: React.FC<Props> = ({
   favorite,
   users,
   maxUsers,
+  locked,
   size,
 
   onClickFavorite,
@@ -86,6 +89,9 @@ export const NavigatorRoomButtonComponent: React.FC<Props> = ({
               y: 1,
             }}
           />
+          {locked ? (
+            <TextComponent text="🔒" position={{ x: size.width - usersWidth - 15 }} />
+          ) : null}
         </ContainerComponent>
         <ContainerComponent
           position={{
@@ -148,6 +154,7 @@ export const NavigatorRoomButtonComponent: React.FC<Props> = ({
       containerProps,
 
       usersColor,
+      locked,
     ],
   );
 };

--- a/app/client/src/shared/consts/modals.consts.ts
+++ b/app/client/src/shared/consts/modals.consts.ts
@@ -65,4 +65,8 @@ export const MODAL_SIZE_MAP: Record<Modal, Size> = {
     width: 281,
     height: 228,
   },
+  [Modal.ROOM_PASSWORD]: {
+    width: 160,
+    height: 70,
+  },
 };

--- a/app/client/src/shared/enums/modal.enums.ts
+++ b/app/client/src/shared/enums/modal.enums.ts
@@ -7,6 +7,7 @@ export enum Modal {
   CLUB,
 
   ROOM_CREATOR,
+  ROOM_PASSWORD,
 }
 
 export enum ModalNavigatorTab {

--- a/app/client/src/shared/hooks/index.ts
+++ b/app/client/src/shared/hooks/index.ts
@@ -16,6 +16,7 @@ export * from "./inventory-notification";
 export * from "./changelog";
 export * from "./language";
 export * from "./api";
+export * from "./room-password-modal";
 
 export * from "./use-character";
 export * from "./use-api-path";

--- a/app/client/src/shared/hooks/modal/modal.provider.tsx
+++ b/app/client/src/shared/hooks/modal/modal.provider.tsx
@@ -27,6 +27,7 @@ import {
   NavigatorComponent,
   PurseComponent,
   RoomCreatorComponent,
+  RoomPasswordComponent,
 } from "modules/modals";
 
 type ModalProps = {
@@ -143,6 +144,7 @@ export const ModalProvider: React.FunctionComponent<ModalProps> = ({
       [Modal.PURSE]: PurseComponent,
       [Modal.CLUB]: ClubComponent,
       [Modal.ROOM_CREATOR]: RoomCreatorComponent,
+      [Modal.ROOM_PASSWORD]: RoomPasswordComponent,
     }),
     [],
   );

--- a/app/client/src/shared/hooks/room-password-modal/index.ts
+++ b/app/client/src/shared/hooks/room-password-modal/index.ts
@@ -1,0 +1,1 @@
+export * from "./room-password-modal.store";

--- a/app/client/src/shared/hooks/room-password-modal/room-password-modal.store.ts
+++ b/app/client/src/shared/hooks/room-password-modal/room-password-modal.store.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+export const useRoomPasswordModalStore = create<{
+  roomId: string | null;
+  setRoomId: (id: string | null) => void;
+}>(
+  (set) => ({
+    roomId: null,
+    setRoomId: (roomId) => set({ roomId }),
+  }),
+);

--- a/app/client/src/shared/types/room.types.ts
+++ b/app/client/src/shared/types/room.types.ts
@@ -55,6 +55,7 @@ export type NavigatorRoom = {
   ownerUsername: string;
   users: number;
   maxUsers: number;
+  hasPassword?: boolean;
   favorite: boolean;
   layoutIndex: number;
 };

--- a/app/server/src/modules/system/game/users.ts
+++ b/app/server/src/modules/system/game/users.ts
@@ -106,6 +106,7 @@ export const users = () => {
 
       emit(ProxyEvent.PRE_JOIN_ROOM, {
         room,
+        hasPassword: Boolean((foundRoom as PrivateRoomMutable).getObject().password),
       });
     };
 

--- a/app/server/src/modules/system/proxy/api/room/list.request.ts
+++ b/app/server/src/modules/system/proxy/api/room/list.request.ts
@@ -48,9 +48,10 @@ export const listRequest: ProxyRequestType = {
                 ownerUsername: await room.getOwnerUsername(),
                 title: room.getTitle(),
                 description: room.getDescription(),
-                userCount: room.getUsers().length,
-                maxUsers: room.getObject().maxUsers,
-                layoutIndex: room.getObject().layoutIndex,
+              userCount: room.getUsers().length,
+              maxUsers: room.getObject().maxUsers,
+              layoutIndex: room.getObject().layoutIndex,
+              hasPassword: Boolean(room.getObject().password),
               })),
           )
         ).sort((roomA, roomB) => (roomA.title > roomB.title ? 1 : -1));

--- a/app/server/src/modules/system/proxy/api/room/room.request.ts
+++ b/app/server/src/modules/system/proxy/api/room/room.request.ts
@@ -46,10 +46,11 @@ export const roomPutRequest: ProxyRequestType = {
   pathname: "",
   method: RequestMethod.PUT,
   func: async ({ data, user }) => {
-    const { layoutId, title, description } = data as unknown as {
+    const { layoutId, title, description, password } = data as unknown as {
       layoutId: number;
       title: string;
       description: string | null;
+      password?: string | null;
     };
     if (!title || isNaN(layoutId)) return { status: 400 };
 
@@ -67,6 +68,7 @@ export const roomPutRequest: ProxyRequestType = {
       furniture: [],
       layoutIndex: layoutId,
       maxUsers: 10,
+      password: password ? password.substring(0, 32) : null,
     };
 
     await System.game.rooms.add(roomData);

--- a/app/server/src/shared/types/rooms/private.types.ts
+++ b/app/server/src/shared/types/rooms/private.types.ts
@@ -14,6 +14,7 @@ export type PrivateRoom = BaseRoom & {
   layoutIndex: number;
   furniture: RoomFurniture[];
   maxUsers: number;
+  password?: string | null;
 };
 
 export type PrivateRoomMutable = BaseRoomMutable & {


### PR DESCRIPTION
## Summary
- add optional password when creating rooms
- indicate password-protected rooms in navigator lists
- require password before joining protected rooms
- implement RoomPassword modal and related store
- update server to handle passwords

## Testing
- `yarn prettier:write` *(fails: connect EHOSTUNREACH)*