### PR TITLE
Fix tsconfig paths and import

### DIFF
--- a/app/client/src/shared/hooks/private-room/private-room.provider.tsx
+++ b/app/client/src/shared/hooks/private-room/private-room.provider.tsx
@@ -1,7 +1,12 @@
 import React, { ReactNode, useCallback, useEffect } from "react";
 import { PrivateRoomContext } from "shared/hooks/private-room/private-room.context";
-import { Direction, Event, Route } from "shared/enums";
-import { useModal, useProxy, useRouter, useRoomPasswordModalStore } from "shared/hooks";
+import { Direction, Event, Route, Modal } from "shared/enums";
+import {
+  useModal,
+  useProxy,
+  useRouter,
+  useRoomPasswordModalStore,
+} from "shared/hooks";
 import { usePrivateRoomStore } from "./private-room.store";
 import { Point3d, PrivateRoom, RoomFurniture, User } from "shared/types";
 

--- a/app/server/tsconfig.json
+++ b/app/server/tsconfig.json
@@ -7,9 +7,10 @@
     "sourceMap": false,
     "noUnusedLocals": true,
     "lib": ["ES2022", "dom"],
-    "baseUrl": "./src/",
-    "rootDir": "./src",
+    "baseUrl": ".",
+    "rootDir": ".",
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmit": true
   }
 }

--- a/app/server/types.d.ts
+++ b/app/server/types.d.ts
@@ -1,0 +1,3 @@
+declare module "@oh/utils";
+declare module "@std/ulid";
+declare module "deno/fs/mod.ts";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,11 @@
     "sourceMap": false,
     "noUnusedLocals": true,
     "lib": ["ES2023", "dom"],
-    "baseUrl": "./src",
-    "rootDir": "./src",
+    "baseUrl": ".",
+    "rootDir": ".",
     "jsx": "react",
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmit": true
   }
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,3 @@
+declare module "@oh/utils";
+declare module "@std/ulid";
+declare module "deno/fs/mod.ts";


### PR DESCRIPTION
## Summary
- fix missing Modal import in PrivateRoomProvider
- adjust tsconfig base settings and disable emit
- add stub declarations for Deno modules

## Testing
- `npx prettier -w app/client/src/shared/hooks/private-room/private-room.provider.tsx app/server/tsconfig.json tsconfig.json types.d.ts app/server/types.d.ts`