### PR TITLE
Add lock indicator and fix room creator form

### DIFF
--- a/app/client/src/modules/modals/components/room-creator/room-creator.component.tsx
+++ b/app/client/src/modules/modals/components/room-creator/room-creator.component.tsx
@@ -209,7 +209,7 @@ export const RoomCreatorComponent: React.FC = () => {
             <TitleComponent
               title={t("room_creator.form.password")}
               position={{
-                y: 14 * 5,
+                y: 14 * 6,
               }}
             >
               <InputComponent

--- a/app/client/src/shared/components/navigator-room-button/navigator-room-button.component.tsx
+++ b/app/client/src/shared/components/navigator-room-button/navigator-room-button.component.tsx
@@ -79,19 +79,19 @@ export const NavigatorRoomButtonComponent: React.FC<Props> = ({
             cursor={Cursor.POINTER}
             onPointerDown={onClickFavorite}
           />
+          {locked ? (
+            <TextComponent text="🔒" color={0xb73d22} position={{ x: 15, y: 1 }} />
+          ) : null}
           <TextComponent
             text={title}
             color={0x1}
-            maxWidth={size.width - usersWidth - 28}
+            maxWidth={size.width - usersWidth - 28 - (locked ? 11 : 0)}
             wrap={false}
             position={{
-              x: 15,
+              x: locked ? 26 : 15,
               y: 1,
             }}
           />
-          {locked ? (
-            <TextComponent text="🔒" position={{ x: size.width - usersWidth - 15 }} />
-          ) : null}
         </ContainerComponent>
         <ContainerComponent
           position={{


### PR DESCRIPTION
## Summary
- make password field appear after description in room creator modal
- show lock icon near room title in navigator list

## Testing
- `yarn prettier:write` *(fails: ConnectTimeoutError)*