### PR TITLE
Fix error when previewing catalog items

### DIFF
--- a/app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx
+++ b/app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx
@@ -88,9 +88,11 @@ export const DefaultCategoryComponent: React.FC<Props> = ({
       (f) => f.id === selectedFurnitureId,
     );
 
-    return selectedFurnitureId
+    const data = get(selectedFurnitureId);
+
+    return selectedFurnitureId && data
       ? {
-          ...get(selectedFurnitureId),
+          ...data,
           price: furniture?.price ?? 0,
         }
       : null;


### PR DESCRIPTION
## Summary
- guard selected furniture data when building preview state

## Testing
- `yarn prettier:check` *(fails: fetch failed)*