### PR TITLE
Fix catalog buy types

### DIFF
--- a/app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx
+++ b/app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx
@@ -17,7 +17,7 @@ import {
   ItemListComponent,
   TextComponent,
 } from "shared/components";
-import { CatalogCategoryData } from "shared/types";
+import { CatalogBuyResponse, CatalogCategoryData } from "shared/types";
 import {
   useApi,
   useFurniture,
@@ -117,7 +117,7 @@ export const DefaultCategoryComponent: React.FC<Props> = ({
       { furnitureId: selectedFurnitureData.furnitureId },
       false,
       "POST",
-    ).then(({ transaction }) => {
+    ).then(({ transaction }: CatalogBuyResponse) => {
       if (transaction?.success) {
         play(SoundsEnum.BUY);
         increment();

--- a/app/client/src/shared/types/catalog.types.ts
+++ b/app/client/src/shared/types/catalog.types.ts
@@ -19,3 +19,9 @@ export type CatalogCategory = {
 export type Catalog = {
   categories: CatalogCategory[];
 };
+
+export type CatalogBuyResponse = {
+  transaction: {
+    success: boolean;
+  };
+};


### PR DESCRIPTION
## Summary
- type the catalog buy API response
- use CatalogBuyResponse when buying an item

## Testing
- `npx prettier -c app/client/src/shared/types/catalog.types.ts app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx`
- `npx tsc -p app/client/tsconfig.json` *(fails: Cannot find module 'react' or its corresponding type declarations)*